### PR TITLE
Wrong in defining module as returned value

### DIFF
--- a/lzo1x.js
+++ b/lzo1x.js
@@ -613,8 +613,8 @@ var lzo1x = (function () {
 
 	return {
 		version: version,
-		compress: _lzo1x.compress(state),
-		decompress: _lzo1x.decompress(state),
+		compress: _lzo1x.compress.bind(_lzo1x),
+		decompress: _lzo1x.decompress.bind(_lzo1x),
 		codes: {
 			OK: _lzo1x.OK,
 			INPUT_OVERRUN: _lzo1x.INPUT_OVERRUN,


### PR DESCRIPTION
```
compress: _lzo1x.compress(state),
decompress: _lzo1x.decompress(state),
```
- state is not defined and unable to pass as argument
- inside implementation of _lzo1x.compress()/decompress(), there are lot of reference to "this" which must be the _lzo1x itself. It is possible to redefine those this.\* as local variable/functions, or you have to bind the function to _lzo1x.
